### PR TITLE
Use Faraday.default_adapter instead of Faraday::Adapter::NetHttp

### DIFF
--- a/lib/kuroko2/updater/client/definition.rb
+++ b/lib/kuroko2/updater/client/definition.rb
@@ -61,7 +61,7 @@ module Kuroko2
               config.basic_auth(ENV.fetch("KUROKO2_API_USER"), ENV.fetch("KUROKO2_API_KEY"))
               config.use FaradayMiddleware::EncodeJson
               config.use FaradayMiddleware::ParseJson
-              config.adapter Faraday::Adapter::NetHttp
+              config.adapter Faraday.default_adapter
             end
           end
       end


### PR DESCRIPTION
## Background

The following error appeared on my applications.

```
/app/vendor/bundle/ruby/2.6.0/gems/faraday-0.17.0/lib/faraday.rb:191:in `lookup_middleware': Faraday::Adapter::NetHttp is not registered on Faraday::Adapter (Faraday::Error)
```

According to [Faraday documentation](https://lostisland.github.io/faraday/adapters/net-http), it seems like the correct way is to specify adapter name using symbol.

However, since [Net::HTTP is the default adapter](https://lostisland.github.io/faraday/adapters/), we can use Faraday.default_adapter instead.

## Changes

* Use `Faraday.default_adapter` instead of `Faraday::Adapter::NetHttp`