### PR TITLE
Fix active_support require

### DIFF
--- a/lib/kuroko2/updater/client/definition.rb
+++ b/lib/kuroko2/updater/client/definition.rb
@@ -1,6 +1,6 @@
 require "faraday"
 require "faraday_middleware"
-require "active_support/isolated_execution_state"
+require "active_support"
 require "active_support/core_ext/hash"
 
 module Kuroko2


### PR DESCRIPTION
This is a follow-up from #9.

Apparently the correct way to cherry-pick something from Active Support is to require `active_support` first then the particular core extension you need, as shown in the [core extension guide](https://edgeguides.rubyonrails.org/active_support_core_extensions.html#loading-grouped-core-extensions):

```ruby
require "active_support"
require "active_support/core_ext/hash"
```

This will properly trigger an autoload for `IsolatedExecutionState` when it is needed.

So, this PR removes the explicit require of `active_support/isolated_execution_state` and instead added a missing `active_support` require.